### PR TITLE
Bugfix for Juce shutdown crash

### DIFF
--- a/modules/danlin_fontawesome/src/FontAwesome.h
+++ b/modules/danlin_fontawesome/src/FontAwesome.h
@@ -16,7 +16,7 @@
 
 typedef juce::Image RenderedIcon;
 
-class FontAwesome {
+class FontAwesome : juce::DeletedAtShutdown {
 public:
     FontAwesome() {}
     ~FontAwesome() {


### PR DESCRIPTION
Inherited FontAwesome from juce::DeletedAtShutdown